### PR TITLE
Add .env.sample and ignore .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+NODE_ENV=development
+DOMAIN=http://localhost:9000
+
+SESSION_SECRET=session-secret
+
+FACEBOOK_ID=facebook-id
+FACEBOOK_SECRET=facebook-secret

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ bower_components
 ### Divvy ###
 build/
 dist/
+.env


### PR DESCRIPTION
API keys, secrets, that should not be pushed
to public repositories should be added to the
.env file.

To create a .env file a .env.sample file has been
added. This file can be copied and renamed as a
template to an actual .env file.

TODO:
  Hook up gulp to load the .env file before starting
  the server.

Resolves #22
