### PR TITLE
Add route to list expense pool members

### DIFF
--- a/server/api/expense-pool/expense-pool.controller.js
+++ b/server/api/expense-pool/expense-pool.controller.js
@@ -7,21 +7,34 @@ const handleError = (res, error) => {
   res.sendStatus(500);
 };
 
-controller.addPool = (req, res) => {
+controller.create = (req, res) => {
   const obj = {};
-  ExpensePool.create(req.body, ['name', 'description', 'imgUrl'])
-  .then(expensePool => {
-    obj.expensePool = expensePool;
-    return expensePool.addUser(req.user);
-  })
-  .then(expensePoolUsers => {
-    obj.expensePoolUsers = expensePoolUsers;
-    res.json(obj);
-  })
-  .catch(error => handleError(res, error));
+  ExpensePool.create(req.body)
+    .then(expensePool => {
+      obj.expensePool = expensePool;
+      return expensePool.addUser(req.user);
+    })
+    .then(expensePoolUsers => {
+      obj.expensePoolUsers = expensePoolUsers;
+      res.json(obj);
+    })
+    .catch(error => handleError(res, error));
 };
 
-controller.addUserToPool = (req, res) => {
+controller.get = (req, res) => {
+  res.json(req.expensePool);
+};
+
+controller.update = (req, res) => {
+  if (req.body._id) {
+    delete req.body._id;
+  }
+  req.expensePool.updateAttributes(req.body)
+    .then(updated => res.json(updated))
+    .catch(error => handleError(res, error));
+};
+
+controller.addUser = (req, res) => {
   req.expensePool.hasUser(req.body.userId)
     .then(isMember => {
       if (isMember) {
@@ -34,16 +47,9 @@ controller.addUserToPool = (req, res) => {
     .catch(error => handleError(res, error));
 };
 
-controller.getPool = (req, res) => {
-  res.json(req.expensePool);
-};
-
-controller.updatePool = (req, res) => {
-  if (req.body._id) {
-    delete req.body._id;
-  }
-  req.expensePool.updateAttributes(req.body)
-    .then(updated => res.json(updated))
+controller.listUsers = (req, res) => {
+  req.expensePool.getUsers()
+    .then(users => res.json(users))
     .catch(error => handleError(res, error));
 };
 

--- a/server/api/expense-pool/index.js
+++ b/server/api/expense-pool/index.js
@@ -1,3 +1,12 @@
+/**
+ * POST  /api/expense-pools/          -> create
+ * GET   /api/expense-pools/:id       -> get
+ * PUT   /api/expense-pools/:id       -> update
+ * PATCH /api/expense-pools/:id       -> update
+ * POST  /api/expense-pools/:id/users -> add user
+ * GET   /api/expense-pools/:id/users -> list users
+ */
+
 import express from 'express';
 import controller from './expense-pool.controller';
 import expenseRouter from './expense';
@@ -6,20 +15,38 @@ import { isPoolMember } from './expense-pool.auth';
 
 const router = express.Router();
 
-// POST => add a new pool
-router.post('/', controller.addPool);
-
-// GET => get a specific pool
-router.get('/:id', isPoolMember(), controller.getPool);
+/**
+ * Create an expense and add req.user as a member
+ *
+ * req.body expected to be key-value pairs of attributes the pool
+ * will be created with.
+ */
+router.post('/', controller.create);
 
 /**
- * POST => Add user to pool
- * Expect body to contain ID of user to add
+ * Get details of specific expense pool
  */
-router.post('/:id/users', isPoolMember(), controller.addUserToPool);
+router.get('/:id', isPoolMember(), controller.get);
 
-router.put('/:id', isPoolMember(), controller.updatePool);
-router.patch('/:id', isPoolMember(), controller.updatePool);
+/**
+ * Update an expense pool's attributes
+ *
+ * req.body expected to be key-value pairs of attributes to update.
+ */
+router.put('/:id', isPoolMember(), controller.update);
+router.patch('/:id', isPoolMember(), controller.update);
+
+/**
+ * Add a user to an expense pool by user id
+ *
+ * req.body expected to be { userId: <some user's _id> }.
+ */
+router.post('/:id/users', isPoolMember(), controller.addUser);
+
+/**
+ * Get users that are members of an expense pool
+ */
+router.get('/:id/users', isPoolMember(), controller.listUsers);
 
 router.use('/:id/expenses', isPoolMember(), expenseRouter);
 


### PR DESCRIPTION
- GET `/api/expense-pool/:id/users` will now return
  an array of users that are members of an expense pool.
- Renamed some `expense-pool.controller` functions
  - Since they are all expense pool related function
    remove "Pool" from the function names.
- Update the doc comments for the expense pool routes

Resolves #118
Resolves #117
