### PR TITLE
Create a gulp build task

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,8 +9,8 @@
   <!-- endbower -->
   <link rel="stylesheet" href="assets/css/app.css">
   <!-- injector:css -->
-  <link rel="stylesheet" href="app/expense-pool/expense-pool.css">
   <link rel="stylesheet" href="app/main/main.css">
+  <link rel="stylesheet" href="app/expense-pool/expense-pool.css">
   <link rel="stylesheet" href="app/components/login/login.css">
   <link rel="stylesheet" href="app/components/navbar/navbar.css">
   <link rel="stylesheet" href="app/expense-pool/expense/expense.css">

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "chai-things": "^0.2.0",
+    "del": "^2.2.1",
     "errorhandler": "^1.4.3",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",


### PR DESCRIPTION
The build task requires linters to pass then:
1. cleans dist folder (leaves the .git folder)
2. transpiles server directly into dist server folder
3. inject and wiredep client index.html
4. copies the client folder files to dist client folder
5. copies over some of the dot files and .json files

Resolves #187
Resolves #67
